### PR TITLE
Feature/support additional http verbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 .mypy_cache/
 /.vs/config
 /LogicMonitor.Api.Test/appsettings.json
+
+# VS Code IDE
+.vscode/

--- a/LogicMonitor.Api.Test/Tests.py
+++ b/LogicMonitor.Api.Test/Tests.py
@@ -27,9 +27,24 @@ class Tests(unittest.TestCase):
 		self.assertEqual(self._config['exampleDeviceId'], device['id'])
 
 	"""
+	Update a specific field of a device (HTTP PATCH)
+	"""
+	def test_02_updateDeviceField_passes(self):
+		updated_description = 'some new description for this device'
+		device_data = json.dumps({
+			'description': updated_description
+		})
+		device = self._client.patch(
+			'/device/devices/{}'.format(self._config['exampleDeviceId']), 
+			queryParams='?patchFields=description',
+			data=device_data)
+		self.assertEqual(device['id'], self._config['exampleDeviceId'])
+		self.assertEqual(updated_description, device['description'])
+
+	"""
 	Create a device SDT
 	"""
-	def test_02_createDeviceSdt_passes(self):
+	def test_03_createDeviceSdt_passes(self):
 		sdt_start_time = int(time.time() * 1000)
 		sdt_end_time = sdt_start_time + int(30 * 60 * 1000)  # 30 minute SDT
 		sdt_comment = 'Test SDT Started At Time ' + str(sdt_start_time)
@@ -51,14 +66,14 @@ class Tests(unittest.TestCase):
 	"""
 	Get a device SDT
 	"""
-	def test_03_getDeviceSdt_passes(self):
+	def test_04_getDeviceSdt_passes(self):
 		sdt = self._client.get('/sdt/sdts/{}'.format(self._sdt_id))
 		self.assertEqual(Tests._sdt_id, sdt['id'])
 
 	"""
 	Update a device SDT
 	"""
-	def test_04_updateDeviceSdt_passes(self):
+	def test_05_updateDeviceSdt_passes(self):
 		sdt_start_time = int(time.time() * 1000) + (60 * 60 * 1000) # Start SDT an hour from now
 		sdt_end_time = sdt_start_time + (180 * 60 * 1000) # 3 hour SDT duration
 		sdt_comment = 'SDT updated at {}'.format(int(time.time() * 1000))
@@ -79,7 +94,7 @@ class Tests(unittest.TestCase):
 	"""
 	Delete a device SDT
 	"""
-	def test_05_deleteDeviceSdt_passes(self):
+	def test_06_deleteDeviceSdt_passes(self):
 		deleted_sdt = self._client.delete('/sdt/sdts/{}'.format(Tests._sdt_id))
 		self.assertIsNone(deleted_sdt)
 

--- a/LogicMonitor.Api.Test/Tests.py
+++ b/LogicMonitor.Api.Test/Tests.py
@@ -1,5 +1,6 @@
 import unittest
 import json
+import time
 from logicmonitor.LogicMonitorClient import LogicMonitorClient
 
 """
@@ -22,8 +23,29 @@ class Tests(unittest.TestCase):
 	"""
 	def test_getDevice_passes(self):
 		device = self._client.get('/device/devices/{0}'.format(self._config['exampleDeviceId']))
-		self.assertEqual(66, device['id'])
+		self.assertEqual(self._config['exampleDeviceId'], device['id'])
 
+	"""
+	Create a device SDT
+	"""
+	def test_createDeviceSdt_passes(self):
+		sdt_start_time = int(time.time() * 1000)
+		sdt_end_time = sdt_start_time + int(30 * 60 * 1000)  # 30 minute SDT
+		sdt_comment = 'Test SDT Started At Time ' + str(sdt_start_time)
+		device_sdt_data = json.dumps({    
+			'sdtType': 1,
+			'type': 'DeviceSDT',
+			'deviceId': self._config['exampleDeviceId'],
+			'startDateTime': sdt_start_time,
+			'endDateTime': sdt_end_time,
+			'comment': sdt_comment
+		})
+		sdt = self._client.post('/sdt/sdts', queryParams='', data=device_sdt_data)
+		self.assertEqual(sdt['deviceId'], self._config['exampleDeviceId'])
+		self.assertEqual(sdt['comment'], sdt_comment)
+		self.assertEqual(sdt['startDateTime'], sdt_start_time)
+		self.assertEqual(sdt['endDateTime'], sdt_end_time)
+		self._sdt_id = sdt['id'] # Store SDT id so we can refer to it later
 """
 Main
 """

--- a/LogicMonitor.Api.Test/Tests.py
+++ b/LogicMonitor.Api.Test/Tests.py
@@ -21,14 +21,14 @@ class Tests(unittest.TestCase):
 	"""
 	Get a device
 	"""
-	def test_getDevice_passes(self):
+	def test_01_getDevice_passes(self):
 		device = self._client.get('/device/devices/{0}'.format(self._config['exampleDeviceId']))
 		self.assertEqual(self._config['exampleDeviceId'], device['id'])
 
 	"""
 	Create a device SDT
 	"""
-	def test_createDeviceSdt_passes(self):
+	def test_02_createDeviceSdt_passes(self):
 		sdt_start_time = int(time.time() * 1000)
 		sdt_end_time = sdt_start_time + int(30 * 60 * 1000)  # 30 minute SDT
 		sdt_comment = 'Test SDT Started At Time ' + str(sdt_start_time)
@@ -45,7 +45,15 @@ class Tests(unittest.TestCase):
 		self.assertEqual(sdt['comment'], sdt_comment)
 		self.assertEqual(sdt['startDateTime'], sdt_start_time)
 		self.assertEqual(sdt['endDateTime'], sdt_end_time)
-		self._sdt_id = sdt['id'] # Store SDT id so we can refer to it later
+		Tests._sdt_id = sdt['id'] # Store SDT id so we can refer to it later
+
+	"""
+	Get a device SDT
+	"""
+	def test_03_getDeviceSdt_passes(self):
+		sdt = self._client.get('/sdt/sdts/{}'.format(self._sdt_id))
+		self.assertEqual(Tests._sdt_id, sdt['id'])
+
 """
 Main
 """

--- a/LogicMonitor.Api.Test/Tests.py
+++ b/LogicMonitor.Api.Test/Tests.py
@@ -3,6 +3,7 @@ import json
 import time
 from logicmonitor.LogicMonitorClient import LogicMonitorClient
 
+
 """
 Unit test class
 """
@@ -53,6 +54,27 @@ class Tests(unittest.TestCase):
 	def test_03_getDeviceSdt_passes(self):
 		sdt = self._client.get('/sdt/sdts/{}'.format(self._sdt_id))
 		self.assertEqual(Tests._sdt_id, sdt['id'])
+
+	"""
+	Update a device SDT
+	"""
+	def test_04_updateDeviceSdt_passes(self):
+		sdt_start_time = int(time.time() * 1000) + (60 * 60 * 1000) # Start SDT an hour from now
+		sdt_end_time = sdt_start_time + (180 * 60 * 1000) # 3 hour SDT duration
+		sdt_comment = 'SDT updated at {}'.format(int(time.time() * 1000))
+		device_sdt_data = json.dumps({    
+			'sdtType': 1,
+			'type': 'DeviceSDT',
+			'deviceId': self._config['exampleDeviceId'],
+			'startDateTime': sdt_start_time,
+			'endDateTime': sdt_end_time,
+			'comment': sdt_comment
+		})
+		sdt = self._client.put('/sdt/sdts/{}'.format(Tests._sdt_id), queryParams='', data=device_sdt_data)
+		self.assertEqual(sdt['id'], Tests._sdt_id)
+		self.assertEqual(sdt['comment'], sdt_comment)
+		self.assertEqual(sdt['startDateTime'], sdt_start_time)
+		self.assertEqual(sdt['endDateTime'], sdt_end_time)
 
 """
 Main

--- a/LogicMonitor.Api.Test/Tests.py
+++ b/LogicMonitor.Api.Test/Tests.py
@@ -76,6 +76,13 @@ class Tests(unittest.TestCase):
 		self.assertEqual(sdt['startDateTime'], sdt_start_time)
 		self.assertEqual(sdt['endDateTime'], sdt_end_time)
 
+	"""
+	Delete a device SDT
+	"""
+	def test_05_deleteDeviceSdt_passes(self):
+		deleted_sdt = self._client.delete('/sdt/sdts/{}'.format(Tests._sdt_id))
+		self.assertIsNone(deleted_sdt)
+
 """
 Main
 """

--- a/LogicMonitor.Api/README.md
+++ b/LogicMonitor.Api/README.md
@@ -7,3 +7,24 @@ Simple example for https://acme.logicmonitor.com/:
 	client = LogicMonitorClient('acme', 'accessIdABCDEF', 'accessKeyGHIJKLMEOP')
 	device = client.get('/device/devices/66')
 	print(device['id'])
+
+	# Update the device
+	device = client.put('/device/devices/66', 
+		queryParams='',
+		data='{"name":"10.1.1.1","displayName":"MonitoredSvr01","preferredCollectorId":20,"hostGroupIds":"2","description":"a server we want to monitor"}')
+	print(device['displayName'])
+
+	# Update a specific property of the device
+	device = client.patch('/device/devices/66',
+		queryParams='?patchFields=description',
+		data='{"description": "new device description!"}')
+	print(device['description'])
+
+	# Delete a device
+	client.delete('/device/devices/66')
+
+	# Create a new device
+	new_device = client.post('/device/devices',
+		queryParams='',
+		data = '{"name":"10.0.1.1","displayName":"ProdServer01","preferredCollectorId":171,"hostGroupIds":2,"customProperties":[{"name":"snmp.version","value":"v3"},{"name":"location","value":"Somewhere"}]}')
+	print(new_device['id])

--- a/LogicMonitor.Api/logicmonitor/LogicMonitorClient.py
+++ b/LogicMonitor.Api/logicmonitor/LogicMonitorClient.py
@@ -52,6 +52,8 @@ class LogicMonitorClient:
 			response = requests.post(url, data=data, headers=headers)
 		elif httpVerb == 'PUT':
 			response = requests.put(url, data=data, headers=headers)
+		elif httpVerb == 'PATCH':
+			response = requests.patch(url, data=data, headers=headers)
 		elif httpVerb == 'DELETE':
 			response = requests.delete(url, data=data, headers=headers)
 		else:
@@ -131,6 +133,25 @@ class LogicMonitorClient:
 		entity = json.loads(response.content)['data']
 		return entity
 
+	"""
+	HTTP PATCH
+	:param resourcePath: The resource path
+	:param queryParams: Optional query parameters
+	:param data: Request parameters
+	"""
+	def patch(self, resourcePath, queryParams = '', data = ''):
+		response = self.response('PATCH', resourcePath, queryParams, data)
+
+		# Status code OK?
+		if(200 != response.status_code):
+			# No
+			raise ValueError('Non-200 response code: {0}'.format(response.status_code))
+		# Yes
+
+		# Return the data node
+		entity = json.loads(response.content)['data']
+		return entity
+	
 	"""
 	HTTP DELETE
 	:param resourcePath: The resource path

--- a/LogicMonitor.Api/logicmonitor/LogicMonitorClient.py
+++ b/LogicMonitor.Api/logicmonitor/LogicMonitorClient.py
@@ -46,7 +46,16 @@ class LogicMonitorClient:
 		}
 
 		#Make request
-		response = requests.get(url, data=data, headers=headers)
+		if httpVerb == 'GET':
+			response = requests.get(url, data=data, headers=headers)
+		elif httpVerb == 'POST':
+			response = requests.post(url, data=data, headers=headers)
+		elif httpVerb == 'PUT':
+			response = requests.put(url, data=data, headers=headers)
+		elif httpVerb == 'DELETE':
+			response = requests.delete(url, data=data, headers=headers)
+		else:
+			raise ValueError('HTTP method "{}" is not supported by the LogicMonitor API!'.format(httpVerb))
 
 		return response
 
@@ -80,6 +89,25 @@ class LogicMonitorClient:
 			raise ValueError('Non-200 response code: {0}'.format(response.status_code))
 		# Yes
 		
+		# Return the data node
+		entity = json.loads(response.content)['data']
+		return entity
+
+	"""
+	HTTP POST
+	:param resourcePath: The resource path
+	:param queryParams: Optional query parameters
+	:param data: Request parameters
+	"""
+	def post(self, resourcePath, queryParams = '', data = ''):
+		response = self.response('POST', resourcePath, queryParams, data)
+
+		# Status code OK?
+		if(200 != response.status_code):
+			# No
+			raise ValueError('Non-200 response code: {0}'.format(response.status_code))
+		# Yes
+
 		# Return the data node
 		entity = json.loads(response.content)['data']
 		return entity

--- a/LogicMonitor.Api/logicmonitor/LogicMonitorClient.py
+++ b/LogicMonitor.Api/logicmonitor/LogicMonitorClient.py
@@ -111,3 +111,22 @@ class LogicMonitorClient:
 		# Return the data node
 		entity = json.loads(response.content)['data']
 		return entity
+
+	"""
+	HTTP PUT
+	:param resourcePath: The resource path
+	:param queryParams: Optional query parameters
+	:param data: Request parameters
+	"""
+	def put(self, resourcePath, queryParams = '', data = ''):
+		response = self.response('PUT', resourcePath, queryParams, data)
+
+		# Status code OK?
+		if(200 != response.status_code):
+			# No
+			raise ValueError('Non-200 response code: {0}'.format(response.status_code))
+		# Yes
+
+		# Return the data node
+		entity = json.loads(response.content)['data']
+		return entity

--- a/LogicMonitor.Api/logicmonitor/LogicMonitorClient.py
+++ b/LogicMonitor.Api/logicmonitor/LogicMonitorClient.py
@@ -130,3 +130,22 @@ class LogicMonitorClient:
 		# Return the data node
 		entity = json.loads(response.content)['data']
 		return entity
+
+	"""
+	HTTP DELETE
+	:param resourcePath: The resource path
+	:param queryParams: Optional query parameters
+	:param data: Request parameters
+	"""
+	def delete(self, resourcePath, queryParams = '', data = ''):
+		response = self.response('DELETE', resourcePath, queryParams, data)
+
+		# Status code OK?
+		if(200 != response.status_code):
+			# No
+			raise ValueError('Non-200 response code: {0}'.format(response.status_code))
+		# Yes
+
+		# Return the data node
+		entity = json.loads(response.content)['data']
+		return entity

--- a/LogicMonitor.Api/setup.py
+++ b/LogicMonitor.Api/setup.py
@@ -3,7 +3,7 @@ setup(
   name = 'logicmonitor',
   description = 'A LogicMonitor API client',
   packages = ['logicmonitor'],
-  version = '0.1.0',
+  version = '0.1.1',
   author = 'David Bond',
   author_email = 'david@davidbondnet',
   url = 'https://github.com/davidnmbond/logicmonitor-api-python',

--- a/README.md
+++ b/README.md
@@ -7,3 +7,25 @@ Simple example for https://acme.logicmonitor.com/:
 	client = LogicMonitorClient('acme', 'accessIdABCDEF', 'accessKeyGHIJKLMEOP')
 	device = client.get('/device/devices/66')
 	print(device['id'])
+
+	# Update the device
+	device = client.put('/device/devices/66', 
+		queryParams='',
+		data='{"name":"10.1.1.1","displayName":"MonitoredSvr01","preferredCollectorId":20,"hostGroupIds":"2","description":"a server we want to monitor"}')
+	print(device['displayName'])
+
+	# Update a specific property of the device
+	device = client.patch('/device/devices/66',
+		queryParams='?patchFields=description',
+		data='{"description": "new device description!"}')
+	print(device['description'])
+
+	# Delete a device
+	client.delete('/device/devices/66')
+
+	# Create a new device
+	new_device = client.post('/device/devices',
+		queryParams='',
+		data = '{"name":"10.0.1.1","displayName":"ProdServer01","preferredCollectorId":171,"hostGroupIds":2,"customProperties":[{"name":"snmp.version","value":"v3"},{"name":"location","value":"Somewhere"}]}')
+	print(new_device['id])
+


### PR DESCRIPTION
Hi David,

I couldn't have discovered your LogicMonitor API client at a better time and was dreading having to start one from scratch! I've added logic to support the other major HTTP methods and tested against our own DEV LogicMonitor environment:

./LogicMonitor.Api.Test/Tests.py -v -f
test_01_getDevice_passes (__main__.Tests) ... ok
test_02_updateDeviceField_passes (__main__.Tests) ... ok
test_03_createDeviceSdt_passes (__main__.Tests) ... ok
test_04_getDeviceSdt_passes (__main__.Tests) ... ok
test_05_updateDeviceSdt_passes (__main__.Tests) ... ok
test_06_deleteDeviceSdt_passes (__main__.Tests) ... ok

My team is particularly interested in automating the management of device SDTs so my tests were focused around CRUD activities for this.
